### PR TITLE
Update Javadoc in LocationContainsKeywordsPredicate

### DIFF
--- a/src/main/java/seedu/address/model/property/LocationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/property/LocationContainsKeywordsPredicate.java
@@ -7,7 +7,7 @@ import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Property};s {code LandlordName} matches any of the keywords given.
+ * Tests that a {@code Property};s {code Location} matches any of the keywords given.
  */
 public class LocationContainsKeywordsPredicate implements Predicate<Property> {
     private final List<String> keywords;


### PR DESCRIPTION
The Javadoc in LocationContainsKeywordsPredicate has been updated to correctly reflect that the class tests for matching keywords in the property’s location rather than the landlord’s name.

Key changes:
* Updated the Javadoc to specify that the predicate tests if a property’s Location matches any of the given keywords.

This change ensures that the documentation accurately reflects the predicate’s functionality, improving code clarity and maintainability.