### PR TITLE
Fix bug where it is null after n/ in edit

### DIFF
--- a/src/main/java/seedu/address/logic/parser/meetup/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meetup/EditCommandParser.java
@@ -78,8 +78,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     /**
      * Parses {@code Collection<String> addedBuyers} into a {@code Set<AddedBuyer>}
      * if {@code addedBuyers} is non-empty.
-     * If {@code addedBuyers} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<AddedBuyer>} containing zero addedBuyer.
+     *
      */
     private Optional<Set<AddedBuyer>> parseAddedBuyersForEdit(Collection<String> addedBuyers) throws ParseException {
         assert addedBuyers != null;
@@ -87,9 +86,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (addedBuyers.isEmpty()) {
             return Optional.empty();
         }
-        Collection<String> addedBuyerSet = addedBuyers.size() == 1 && addedBuyers.contains("")
-                ? Collections.emptySet() : addedBuyers;
-        return Optional.of(ParserUtil.parseAddedBuyers(addedBuyerSet));
+
+        return Optional.of(ParserUtil.parseAddedBuyers(addedBuyers));
     }
 
     /**


### PR DESCRIPTION
For edit command in Meet up mode, users are able to input `edit 1 n/` which will remove all addedBuyers from the meet-up, a loophole that allow them to break the definition of a meet-up where there should at least be one added buyer.

This bug fix prevents users from doing that.